### PR TITLE
chore: inline CI pipeline per ADR-004

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -1,0 +1,17 @@
+name: auto-labeler
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  auto-labeler:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    uses: platform-mesh/.github/.github/workflows/job-auto-labeler.yml@main

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -1,4 +1,5 @@
-name: pipe
+name: ci
+
 on:
   push:
     branches:
@@ -8,14 +9,96 @@ on:
       - opened
       - synchronize
 
+permissions:
+  contents: write
+  id-token: write
+  issues: write
+  packages: write
+  pull-requests: write
+
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  pipe:
-    uses: platform-mesh/.github/.github/workflows/pipeline-node-app.yml@main
+  # ──────────────────────────────────────────────
+  # Always-run jobs (PR + main)
+  # ──────────────────────────────────────────────
+  test:
+    uses: platform-mesh/.github/.github/workflows/job-node-test.yml@main
     secrets: inherit
+
+  docker-build:
+    if: github.event_name == 'pull_request'
+    uses: platform-mesh/.github/.github/workflows/job-docker-build-push.yml@main
     with:
       imageTagName: ghcr.io/platform-mesh/iam-ui
-      componentVersionKey: iam-ui
+    secrets: inherit
+
+  # ──────────────────────────────────────────────
+  # Quality gate (aggregates required checks)
+  # ──────────────────────────────────────────────
+  quality-gate:
+    if: always()
+    permissions: {}
+    needs: [test, docker-build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ needs.test.result }}" != "success" ]]; then
+            echo "test failed"
+            exit 1
+          fi
+          # docker-build is skipped on main pushes — allow skipped
+          if [[ "${{ needs.docker-build.result }}" != "success" && "${{ needs.docker-build.result }}" != "skipped" ]]; then
+            echo "docker-build failed"
+            exit 1
+          fi
+
+  # ──────────────────────────────────────────────
+  # Release jobs (main branch only)
+  # ──────────────────────────────────────────────
+  create-version:
+    if: github.ref == 'refs/heads/main'
+    uses: platform-mesh/.github/.github/workflows/job-create-version.yml@main
+    secrets: inherit
+
+  docker-build-push:
+    if: github.ref == 'refs/heads/main'
+    needs: [create-version, test]
+    uses: platform-mesh/.github/.github/workflows/job-docker-build-push.yml@main
+    with:
+      imageTagName: ghcr.io/platform-mesh/iam-ui
+      version: ${{ needs.create-version.outputs.version }}
+      multiarch: true
+    secrets: inherit
+
+  update-version:
+    if: github.ref == 'refs/heads/main'
+    needs: [create-version, docker-build-push]
+    uses: platform-mesh/.github/.github/workflows/job-chart-version-update.yml@main
+    secrets: inherit
+    with:
+      appVersion: ${{ needs.create-version.outputs.version }}
+      chart: iam-ui
+      targetRepository: platform-mesh/helm-charts
+
+  sbom:
+    if: github.ref == 'refs/heads/main'
+    needs: [create-version, docker-build-push]
+    uses: platform-mesh/.github/.github/workflows/job-sbom.yml@main
+    with:
+      imageReference: ghcr.io/platform-mesh/iam-ui:${{ needs.create-version.outputs.version }}
+
+  image-ocm:
+    if: github.ref == 'refs/heads/main'
+    needs: [create-version, docker-build-push, sbom]
+    uses: platform-mesh/.github/.github/workflows/job-image-ocm.yml@main
+    secrets: inherit
+    with:
+      imageReference: ghcr.io/platform-mesh/iam-ui:${{ needs.create-version.outputs.version }}
+      appVersion: ${{ needs.create-version.outputs.version }}
+      repoName: iam-ui
+      commit: ${{ github.sha }}


### PR DESCRIPTION
## Summary

- Inlines the `pipeline-node-app.yml` shared workflow into the repository per [ADR-004](https://github.com/platform-mesh/architecture/blob/main/adr/004-shared-ci-workflow-strategy.md)
- Adds `quality-gate` job as aggregated required status check
- Adds `auto-labeler` workflow