### PR TITLE
chore: update renovate config to use platform-mesh preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>dxp/.github:renovate-config"]
+  "extends": [
+    "local>platform-mesh/.github:renovate-config"
+  ]
 }


### PR DESCRIPTION
## Summary

- Update renovate extends preset from `local>dxp/.github:renovate-config` to `local>platform-mesh/.github:renovate-config`
- Aligns with all other platform-mesh repos (portal, account-operator, platform-mesh-operator, iam-service, etc.)