### PR TITLE
feat(ci): add attestations permission for build provenance

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -15,6 +15,7 @@ permissions:
   issues: write
   packages: write
   pull-requests: write
+  attestations: write
 
 concurrency:
   group: ${{ github.ref }}


### PR DESCRIPTION
## Summary

- Adds `attestations: write` to workflow permissions, enabling the SLSA build provenance attestation step in the shared `job-docker-build-push` workflow (platform-mesh/.github#147)

Ref: platform-mesh/backlog#229