### PR TITLE
Pin Dockerfile dependencies to hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN npm ci
 
 RUN npm run build
 
-FROM nginx:alpine
+FROM nginx:alpine@sha256:8b1e78743a03dbb2c95171cc58639fef29abc8816598e27fb910ed2e621e589a
 COPY --from=build /app/dist-ui /usr/share/nginx/html/ui/iam/ui
 COPY --from=build /app/dist-wc /usr/share/nginx/html/ui/iam/wc
 COPY nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
As per [the latest Scorecard report](https://scorecard.dev/viewer/?uri=github.com/platform-mesh/iam-ui&sort_by=check-score&sort_direction=asc):

```
Warn: containerImage not pinned by hash: Dockerfile:10: pin your Docker image by updating nginx:alpine to nginx:alpine@sha256:8b1e78743a03dbb2c95171cc58639fef29abc8816598e27fb910ed2e621e589a
```